### PR TITLE
OAuth correctly redirects to Heroku.

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -8,7 +8,7 @@ require('dotenv/config')
 
 const clientId = 'ee3918a44251433a87cbc842f68bc29f'
 const clientSecret = process.env.CLIENT_SECRET
-const redirectURI = 'http://localhost:7777/callback'
+const redirectURI = 'https://social-spotify-jjnotjayjay.herokuapp.com/callback'
 
 const app = express()
 app.use(express.static(path.join(__dirname, '/public')))


### PR DESCRIPTION
![oauth-heroku](https://user-images.githubusercontent.com/39274776/47885529-c6af4700-ddf2-11e8-98b1-c220133f997e.gif)
